### PR TITLE
Multiple metrics in a single query

### DIFF
--- a/Data/ApplicationDbContext.cs
+++ b/Data/ApplicationDbContext.cs
@@ -140,7 +140,12 @@ public class ApplicationDbContext : DbContext
             entity.HasKey(e => e.Id);
             entity.Property(e => e.Name).IsRequired().HasMaxLength(100);
             entity.Property(e => e.Description).IsRequired().HasMaxLength(500);
-            entity.Property(e => e.PrometheusIdentifier).IsRequired().HasMaxLength(200);
+            entity.Property(e => e.PrometheusIdentifier)
+                .IsRequired()
+                .HasConversion(
+                    v => string.Join(',', v),
+                    v => v.Split(',', StringSplitOptions.RemoveEmptyEntries).Select(s => s.Trim()).ToList())
+                .HasMaxLength(200);
             entity.Property(e => e.Unit).IsRequired(false).HasMaxLength(50);
             entity.Property(e => e.CreatedAt).IsRequired();
             entity.Property(e => e.CreatedBy).IsRequired(false);

--- a/Dtos/MetricsDto.cs
+++ b/Dtos/MetricsDto.cs
@@ -9,6 +9,6 @@ public class MetricsDto
     [Required]
     public string Description { get; set; }
     [Required]
-    public string PrometheusIdentifier { get; set; }
+    public List<string> PrometheusIdentifier { get; set; } = new List<string>();
     public string? Unit { get; set; }
 }

--- a/Models/MetricType.cs
+++ b/Models/MetricType.cs
@@ -9,7 +9,7 @@ public class MetricType : BaseModel
     [Required]
     public string Description { get; set; }
     [Required]
-    public string PrometheusIdentifier { get; set; }
+    public List<string> PrometheusIdentifier { get; set; } = new List<string>();
 
     public string? Unit { get; set; }
 }


### PR DESCRIPTION
Did minor changes to allow for comma seperation using regex, which makes it possible to add a query with a list of metrics to query from Prometheus, in the style: "jetson_cpu_temp, jetson_gpu_temp, ..." and so on.

It does each query individually, and adds each JsonElement to a list, which collects the results from each query